### PR TITLE
Compiler warning fix

### DIFF
--- a/Sources/Glur/CompatibilityModifier.swift
+++ b/Sources/Glur/CompatibilityModifier.swift
@@ -26,7 +26,7 @@ internal struct CompatibilityModifier: ViewModifier {
     }
     
     var gradientMask: some View {
-        var (startPoint, endPoint) = direction.unitPoints
+        let (startPoint, endPoint) = direction.unitPoints
         
         return LinearGradient(stops: [
             .init(color: .clear, location: 0),

--- a/Sources/Glur/blur.metal
+++ b/Sources/Glur/blur.metal
@@ -28,6 +28,10 @@ float mapRadius(float2 position,
         mapped = max((position.x/size.x*displayScale-offset)/interpolation, 0.0);
     } else if (direction == 3) {
         mapped = max(0.5-(position.x/size.x*displayScale-offset)/interpolation, 0.0);
+    } else {
+        // This suppresses the compiler warning "Variable 'mapped' is used uninitialized
+        // whenever 'if' condition is false".
+        mapped = 0;
     }
     
     return min(mapped*radius, radius);


### PR DESCRIPTION
Thank you for creating Glur and sharing it! It's awesome. I'm using it in a special relativity explainer app I'm writing for Apple Vision Pro.

This PR fixes a harmless compiler warning that appears in blur.metal when the Glur is added to a project as a Swift Package Manager dependency.

This is how the compiler warnings appears in Xcode 15.4 beta:
<img width="1374" alt="uninitialized-variable" src="https://github.com/joogps/Glur/assets/12141562/efc7891b-8ea1-4358-a8b0-133c270329fa">

This PR also fixes an unrelated compiler warning in CompatibilityModifier.swift which is less important and does not show up when an including project is built.

Please let me know if you have any questions. Thanks for considering this PR.
